### PR TITLE
convert docs to use verb

### DIFF
--- a/.verbrc.md
+++ b/.verbrc.md
@@ -1,6 +1,6 @@
-# assemble-examples-markdown [![NPM version](https://badge.fury.io/js/assemble-examples-markdown.png)](http://badge.fury.io/js/assemble-examples-markdown)
+# {%= name %} {%= badge("fury") %}
 
-> Use Assemble to generate HTML pages from markdown content. Useful for wikis, gh-pages, documentation and blogs or sites with markdown posts.
+> {%= description %}
 
 #### Thank you to [Upstage](https://github.com/upstage) for the theme used in the [live demo](http://assemble.github.io/boilerplate-markdown) (the same used on http://assemble.io)!
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -60,6 +60,7 @@ module.exports = function(grunt) {
   // Load npm plugins to provide necessary tasks.
   grunt.loadNpmTasks('assemble');
   grunt.loadNpmTasks('grunt-contrib-clean');
+  grunt.loadNpmTasks('grunt-verb');
 
   // Default tasks to be run.
   grunt.registerTask('default', ['assemble']);

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
     "blog generator",
     "handlebars",
     "templates"
-  ]
+  ],
+  "devDependencies": {
+    "grunt-verb": "~0.2.3"
+  }
 }


### PR DESCRIPTION
Before assemble releases v0.5.0, repos need to use verb for creating README.md.
assemble/assemble#501
